### PR TITLE
Fix missing } in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ local kube_utils_mappings = {
   { "<leader>kl", group = "Logs" },
   { "<leader>klf", "<cmd>JsonFormatLogs<CR>", desc = "Format JSON" },
   { "<leader>klv", "<cmd>ViewPodLogs<CR>", desc = "View Pod Logs" },
-
+}
 -- Register the Kube Utils keybindings
 require('which-key').add(kube_utils_mappings)
 ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ return {
 Use the following mappings to access Kubernetes features efficiently:
 
 ```lua
+-- ~/.config/nvim/lua/config/keymaps.lua
 local kube_utils_mappings = {
   { "<leader>k", group = "Kubernetes" }, -- Main title for all Kubernetes related commands
   -- Helm Commands


### PR DESCRIPTION
The code block in the readme for `~/.config/nvim/lua/configs/keymaps.lua` was missing a filepath which has been added for consistency with with the plugins code block. It was also missing a closing curly brace in a very important spot. This has also been added.